### PR TITLE
fix: fixing docs and content set validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ In Web.config set those configurations:
 
 
 ```xml
-<add key="IsInternalIndexDisabled" value="true" />
+<add key="Cogworks.Examine.Tweaks.InternalIndexDisabled" value="true" />
 ```
 
 - Disabling **External** index (default false):

--- a/Source/Cogworks.Examine.Tweaks/Configurations/CustomIndexConfig.cs
+++ b/Source/Cogworks.Examine.Tweaks/Configurations/CustomIndexConfig.cs
@@ -21,7 +21,7 @@ namespace Cogworks.Examine.Tweaks.Configurations
             => !(!TweaksConfiguration.InternalIncludedItemTypes.HasAny()
                     && !TweaksConfiguration.InternalExcludedItemTypes.HasAny())
                 ? new ContentValueSetValidator(
-                    publishedValuesOnly: true,
+                    publishedValuesOnly: false,
                     supportProtectedContent: true,
                     publicAccessService: _publicAccessService,
                     scopeProvider: _scopeProvider,


### PR DESCRIPTION
fixing docs and content value set validator

<!--
Thank you for your pull request, #h5yr! But it's just a beginning. 
Please provide details where it's required and review the requirements below.
-->
Fixing wrong appsettings key in docs.
Content set validator should include not only published data.


---

**Checklist**:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] My PR has a descriptive title (not a vague title like `Needed this`)
- [x] Title and all the commits follow [commitlint guidelines](https://github.com/conventional-changelog/commitlint#what-is-commitlint)
- [x] My PR targets the `develop` branch or appropriate `release` branch
- [ ] I've placed the link to the corresponding Trello card or issue which this PR fixes/address below ⤵️

---

Fixes: ### ISSUE_OR_TRELLO_LINK ###